### PR TITLE
fix integTest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ ifdef JENKINS_URL
 	./build/scripts/cleanup.sh ${CLUSTER_NAME}
 endif
 	echo 'Create cluster...'
-	time kind create cluster \
+	HTTP_PROXY="" HTTPS_PROXY="" http_proxy="" https_proxy="" time kind create cluster \
 	    --name ${CLUSTER_NAME} \
 	    --wait 5m \
 		--config=test/kind-config.yaml
@@ -132,8 +132,6 @@ ifdef JENKINS_URL
 	cat ${HOME}/.kube/config | grep server
 endif
 	kubectl cluster-info
-
-	kubectl wait --for=condition=ready nodes --all
 	kubectl get nodes
 	echo 'Copy operator Docker image into KinD...'
 	kind load --name ${CLUSTER_NAME} docker-image ${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ ifdef JENKINS_URL
 	./build/scripts/cleanup.sh ${CLUSTER_NAME}
 endif
 	echo 'Create cluster...'
-	HTTP_PROXY="" HTTPS_PROXY="" http_proxy="" https_proxy="" time kind create cluster \
+	time kind create cluster \
 	    --name ${CLUSTER_NAME} \
 	    --wait 5m \
 		--config=test/kind-config.yaml


### PR DESCRIPTION
The integ-test runs in master branch very often failed in "kubectl wait --for=condition=ready nodes --all" as following 

kubectl wait --for=condition=ready nodes --all
node/v8o-cluster-operator-control-plane condition met
error: timed out waiting for the condition on nodes/v8o-cluster-operator-worker
make: *** [integ-test] Error 1

This is caused by `kubectl wait --for=condition=ready nodes --all`
Rmoving `kubectl wait --for=condition=ready nodes --all` does not have negative effect.